### PR TITLE
Use app specific password instead of normal one

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -33,7 +33,7 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec fastlane beta
       env:
-        FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+        FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
         MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
     - name: Upload IPA
       uses: actions/upload-artifact@v2

--- a/.github/workflows/enterprise.yml
+++ b/.github/workflows/enterprise.yml
@@ -35,7 +35,6 @@ jobs:
         bundle exec fastlane run increment_build_number build_number:$GITHUB_RUN_NUMBER
         bundle exec fastlane enterprise
       env:
-        FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
         MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         APPCENTER_API_TOKEN: ${{ secrets.APPCENTER_API_TOKEN }}
     - name: Upload IPA


### PR DESCRIPTION
To make GitHub Actions work with 2FA.