### PR TITLE
Remove SwiftLint from Brew bundle

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,2 @@
-brew "swiftlint"
 brew "imagemagick"
 brew "librsvg"


### PR DESCRIPTION
SwiftLint is preinstalled on all the CI runnners we use.