### PR TITLE
Use GitHub token for Danger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec fastlane test
       env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We don't need separate user for Danger anymore. We can use the token provided by GitHub Actions.