### PR TITLE
Remove xcpretty formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem "fastlane"
 gem "cocoapods"
 gem "danger"
 gem "thefuntasty_danger"
-gem "xcpretty-json-formatter"
 
 # Fastlane plugins
 gem "fastlane-plugin-badge"


### PR DESCRIPTION
It is deprecated and we will start using xcresult for Danger summaries.

https://github.com/futuredapp/danger/pull/29