### PR TITLE
Switch to cron

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   schedule:
-    - cron: '0 1 * * 1-5'
+    - cron: '0 1 * * 2-6'
 
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: Build
 
 on:
-  push:
-    branches:
-    - develop
+  schedule:
+    - cron: '0 1 * * 1-5'
+
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build
 
 on:
   # Schedule https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
-  # Schedule to run this at 11:00 and 22:00 UTC+2 every monday to friday
+  # Schedule to run this at 00:00 UTC every tuesday to saturday
   # check cron syntax https://crontab.guru/
   schedule:
-    - cron: '0 1 * * 2-6'
+    - cron: '0 0 * * 2-6'
 
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 
 on:
+  # Schedule https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+  # Schedule to run this at 11:00 and 22:00 UTC+2 every monday to friday
+  # check cron syntax https://crontab.guru/
   schedule:
     - cron: '0 1 * * 2-6'
 


### PR DESCRIPTION
Build akce se nyní budou volat úterý - sobota o půlnoci UTC (sobota aby to bylo po pracovním pátku, netřeba pak buildit v pondělí)
Přidána možnost zavolat ručně pokud bude potřeba.