### PR TITLE
Add Bundler version to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,2 @@
+BUNDLED WITH
+  2.7.2


### PR DESCRIPTION
Temporary lock bundler version - `bundle install` fails at the moment without this file after bundler v4 release